### PR TITLE
RGB-010 chunk container rebound walls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Physics, Debug } from '@react-three/cannon'
 import {   
+  ChunkContainer,
   Container,
   ExplosionController,
   ScreenSettings,
@@ -44,7 +45,8 @@ function App() {
           <Debug scale={1} color='green'>
             <ShapeController/>
             <ExplosionController/>
-            <Container ref={boxRef} />
+            <Container ref={boxRef}/>
+            <ChunkContainer/>
           </Debug>
         </Physics>
       </Canvas>

--- a/src/app.config.js
+++ b/src/app.config.js
@@ -1,14 +1,24 @@
 
+
 const CONTAINER_WIDTH = 10
 const SHAPE_WIDTH_HEIGHT = CONTAINER_WIDTH * .33 * 0.8
 const CHUNK_WIDTH_HEIGHT = SHAPE_WIDTH_HEIGHT * 0.5
 const CHUNK_START_POSITION_OFFSET = CHUNK_WIDTH_HEIGHT * 0.5
+
+export const COLLISION_GROUPS = {
+  CONTAINER: 2 ** 0,
+  SHAPE: 2 ** 1,
+  CHUNK: 2 ** 2,
+  CHUNK_CONTAINER: 2 ** 3
+}
 
 export const CONTAINER = {
   width: CONTAINER_WIDTH,
   depth: CONTAINER_WIDTH * .33,
   wallThickness: .5,
 }
+
+
 
 export const SHAPE = {
   colors: ['#ff0000', '#00ff00', '#0000ff'],
@@ -25,12 +35,7 @@ export const SHAPE = {
   }
 }
 
-export const COLLISION_GROUPS = {
-  CONTAINER: 2 ** 0,
-  SHAPE: 2 ** 1,
-  CHUNK: 2 ** 2,
-  FLOOR: 2 ** 3
-}
+
 
 export const CHUNK = {
   angularVelocity: [
@@ -40,7 +45,7 @@ export const CHUNK = {
     [-2.5, 5, 3]
   ],
   collisionFilterGroup: COLLISION_GROUPS.CHUNK,
-  collisionFilterMask: COLLISION_GROUPS.CHUNK,
+  collisionFilterMask: COLLISION_GROUPS.CHUNK | COLLISION_GROUPS.CHUNK_CONTAINER,
   args: {
     'sphereChunk': [CHUNK_WIDTH_HEIGHT * .25],
     'boxChunk': [CHUNK_WIDTH_HEIGHT, CHUNK_WIDTH_HEIGHT, CHUNK_WIDTH_HEIGHT]

--- a/src/components/ChunkContainer/ChunkContainer.jsx
+++ b/src/components/ChunkContainer/ChunkContainer.jsx
@@ -1,0 +1,33 @@
+import useStore from '../../store/useStore'
+import ChunkContainerWall from './ChunkContainerWall'
+import { getChunkContainerProps } from './chunkContainer.helper'
+
+
+const ChunkContainer = () => {
+  const { containerWidth, containerHeight,  containerDepth, containerThickness } = useStore((state) => state)
+  const _chunkContainerProps = getChunkContainerProps({
+    containerWidth, 
+    containerHeight,  
+    containerDepth, 
+    containerThickness
+  })
+
+  return (
+    <group>
+      {Object.keys(_chunkContainerProps).map((name) => {
+        const { size, position } = _chunkContainerProps[name]
+        return (
+          <ChunkContainerWall
+            size={size}
+            position={position}
+            key={name}
+            name={name}
+          /> 
+        )
+      })
+    }
+    </group>
+  )
+}
+
+export default ChunkContainer

--- a/src/components/ChunkContainer/ChunkContainerWall.jsx
+++ b/src/components/ChunkContainer/ChunkContainerWall.jsx
@@ -1,0 +1,25 @@
+import { COLLISION_GROUPS } from '../../app.config';
+import { useBox } from '@react-three/cannon'
+
+const ChunkContainerWall = ({
+  size,
+  position,
+  name }) => {
+
+  const [ref] = useBox(() => ({
+    collisionFilterGroup: COLLISION_GROUPS.CHUNK_CONTAINER,
+    collisionFilterMask: COLLISION_GROUPS.CHUNK | COLLISION_GROUPS.CHUNK_CONTAINER,
+    args: size,
+    position
+  }))
+
+
+  return (
+    <mesh ref={ref} name={name}>
+      <boxGeometry args={size}/>
+      <meshStandardMaterial visible={false} />
+    </mesh>
+  )
+}
+
+export default ChunkContainerWall

--- a/src/components/ChunkContainer/chunkContainer.helper.js
+++ b/src/components/ChunkContainer/chunkContainer.helper.js
@@ -1,0 +1,33 @@
+
+
+export const getChunkContainerProps = ({
+  containerWidth, 
+  containerHeight,  
+  containerDepth, 
+  containerThickness
+}) => ({
+  left: {
+    size: [
+      containerThickness, 
+      containerHeight,  
+      containerDepth * 2
+    ],
+    position: [
+      -containerWidth * .5, 
+      containerHeight * .5, 
+      containerDepth * 1.5
+    ]
+  },
+  right: {
+    size: [
+      containerThickness, 
+      containerHeight,  
+      containerDepth * 2
+    ],
+    position: [
+      containerWidth * .5, 
+      containerHeight * .5, 
+      containerDepth * 1.5
+    ]
+  }
+})

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,8 +2,10 @@ import Container from './Container/Container'
 import ExplosionController from './ExplosionController/ExplosionController'
 import ScreenSettings from './ScreenSettings/ScreenSettings'
 import ShapeController from './ShapeController/ShapeController'
+import ChunkContainer from './ChunkContainer/ChunkContainer'
 
 export {
+  ChunkContainer,
   Container,
   ExplosionController,
   ScreenSettings,

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -14,7 +14,7 @@ const useStore = create(
     // shapes
     shapes: [],
     shapeId: 2,
-    shapeLevel: 'spheres',
+    shapeLevel: 'boxes',
     spawnShape: ({x, y}) => {
       set((state) => {
         const _shapeId = state.shapeId + 1

--- a/src/utils/quaternionFromAxisAngle.js
+++ b/src/utils/quaternionFromAxisAngle.js
@@ -1,0 +1,7 @@
+import { Quaternion, Vector3 } from 'three'
+
+export const quaternionFromAxisAngle = ({x, y, z}, radians) => {
+  const quaternion = new Quaternion();
+  quaternion.setFromAxisAngle(new Vector3(x, y, z), radians);
+  return quaternion;
+}


### PR DESCRIPTION
Ticket RBG-010
- Add walls extending forward from the shape container to make explosion chunks rebound toward the center of the screen.

https://github.com/user-attachments/assets/fe74f531-ddc9-41d3-8ff8-efe1ce33816c

