### PR TITLE
RBG-011 level intro auto drop shapes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import {
   ChunkContainer,
   Container,
   ExplosionController,
+  GameStages,
   ScreenSettings,
   ShapeController } from './components'
 import { CameraControls } from '@react-three/drei';
@@ -41,6 +42,7 @@ function App() {
         <CameraControls makeDefault ref={controlsRef} />
         <hemisphereLight args={[0x606060, 0x404040]} />
         <directionalLight position={[1, 1, 1]}/>
+        <GameStages/>
         <Physics defaultContactMaterial={{ friction: 0.1, restitution: 0.5 }} gravity={[0, -19, 0]}>
           <Debug scale={1} color='green'>
             <ShapeController/>

--- a/src/app.config.js
+++ b/src/app.config.js
@@ -1,7 +1,7 @@
 
 
-const CONTAINER_WIDTH = 10
-const SHAPE_WIDTH_HEIGHT = CONTAINER_WIDTH * .33 * 0.8
+export const CONTAINER_WIDTH = 10
+export const SHAPE_WIDTH_HEIGHT = CONTAINER_WIDTH * .33 * 0.8
 const CHUNK_WIDTH_HEIGHT = SHAPE_WIDTH_HEIGHT * 0.5
 const CHUNK_START_POSITION_OFFSET = CHUNK_WIDTH_HEIGHT * 0.5
 
@@ -18,8 +18,6 @@ export const CONTAINER = {
   wallThickness: .5,
 }
 
-
-
 export const SHAPE = {
   colors: ['#ff0000', '#00ff00', '#0000ff'],
   widthHeight: SHAPE_WIDTH_HEIGHT,
@@ -35,7 +33,7 @@ export const SHAPE = {
   }
 }
 
-
+export const LEVEL_ORDER = ['spheres', 'boxes', 'sphereBoxSphere', 'boxSphereBox']
 
 export const CHUNK = {
   angularVelocity: [
@@ -70,11 +68,10 @@ export const CHUNK = {
 }
 
 export const GAME_STAGES = {
-  INIT: 'INIT',
-  MENU: 'MENU',
-  PLAY: 'PLAY',
-  WIN: 'WIN',
-  LOSE: 'LOSE',
-  PAUSE: 'PAUSE'
+  IntroGame: 'IntroGame',
+  SelectLevel: 'SelectLevel',
+  IntroLevel: 'IntroLevel',
+  PlayLevel: 'PlayLevel',
+  WinLevel: 'WinLevel'
 }
 

--- a/src/components/Container/Container.jsx
+++ b/src/components/Container/Container.jsx
@@ -1,11 +1,12 @@
 import useStore from '../../store/useStore'
 import ContainerWall from './ContainerWall'
+import { GAME_STAGES } from '../../app.config'
 import { getContainerProps } from './container.helpers';
 import { forwardRef } from 'react';
 
 
 const Container = forwardRef((props, ref) => {
-  const { spawnShape, containerWidth, containerHeight,  containerDepth, containerThickness } = useStore((state) => state)
+  const { spawnShape, containerWidth, containerHeight,  containerDepth, containerThickness, gameStage } = useStore((state) => state)
   const _containerProps = getContainerProps({
     containerWidth, 
     containerHeight,  
@@ -14,8 +15,10 @@ const Container = forwardRef((props, ref) => {
   })
 
  const handleOnClick = (e) => {
-  const { x, y } = e.point
-  spawnShape({ x, y})
+  if (gameStage === GAME_STAGES.PlayLevel) {
+    const { x, y } = e.point
+    spawnShape({ x, y})
+  }
  }
 
   return (

--- a/src/components/GameStages/GameStages.jsx
+++ b/src/components/GameStages/GameStages.jsx
@@ -1,0 +1,22 @@
+import IntroGame from './IntroGame'
+import SelectLevel from './SelectLevel'
+import IntroLevel from './IntroLevel'
+import PlayLevel from './PlayLevel'
+import WinLevel from './WinLevel'
+
+
+const GameStages = () => {
+  
+  return (
+    <>
+      <IntroGame/>
+      {/* <SelectLevel/> */}
+      <IntroLevel/>
+      <PlayLevel/>
+      <WinLevel/>
+    </>
+  )
+
+}
+
+export default GameStages

--- a/src/components/GameStages/IntroGame.jsx
+++ b/src/components/GameStages/IntroGame.jsx
@@ -1,0 +1,19 @@
+import useStore from '../../store/useStore'
+import { GAME_STAGES } from '../../app.config'
+
+const IntroGame = () => {
+  const { gameStage, setGameStage } = useStore((state) => state)
+
+  if (gameStage !== GAME_STAGES.IntroGame) {
+    return null
+  }
+ console.log('IntroGame Active')
+  const handleClickStart = () => {
+    setGameStage(GAME_STAGES.IntroLevel)
+  }
+
+  return null
+}
+
+
+export default IntroGame;

--- a/src/components/GameStages/IntroLevel.jsx
+++ b/src/components/GameStages/IntroLevel.jsx
@@ -1,0 +1,35 @@
+import useStore from '../../store/useStore'
+import { GAME_STAGES, SHAPE_WIDTH_HEIGHT, CONTAINER_WIDTH } from '../../app.config'
+import { useEffect } from 'react'
+
+
+const IntroLevel = () => {
+  const { spawnShape, gameStage, setGameStage, containerHeight } = useStore((state) => state)
+
+  useEffect(() => {
+    if (gameStage !== GAME_STAGES.IntroLevel) {
+      return
+    }
+
+    let shapeCount = 3
+    const xOffsetIncrement = SHAPE_WIDTH_HEIGHT * 1.05
+    const startX = -xOffsetIncrement
+    const spawnIntroShape = () => {
+      const offsetX = startX + (3 - shapeCount) * xOffsetIncrement
+      spawnShape({ x: offsetX, y: containerHeight - SHAPE_WIDTH_HEIGHT}) 
+      shapeCount -= 1;
+      if (!shapeCount) {
+        clearInterval(intervalId)
+        setGameStage(GAME_STAGES.PlayLevel)
+      }
+    }
+    const intervalId = setInterval(spawnIntroShape, 500)
+    return () => clearInterval(intervalId)
+  }, [gameStage])
+
+  
+  return null
+}
+
+
+export default IntroLevel;

--- a/src/components/GameStages/PlayLevel.jsx
+++ b/src/components/GameStages/PlayLevel.jsx
@@ -1,0 +1,26 @@
+import useStore from '../../store/useStore'
+import { useEffect } from 'react'
+import { GAME_STAGES } from '../../app.config'
+
+const PlayLevel = () => {
+  const { gameStage, setGameStage, containerHeight, shapesBoxHeight } = useStore((state) => state)
+
+
+  useEffect(() => {
+
+    if (gameStage !== GAME_STAGES.PlayLevel) {
+      return
+    }
+
+    if (shapesBoxHeight > containerHeight) {
+      setGameStage(GAME_STAGES.WinLevel)
+    }
+
+  }, [gameStage, shapesBoxHeight, containerHeight])
+
+
+  return null // shapesBoxHeight indicator?
+}
+
+
+export default PlayLevel;

--- a/src/components/GameStages/SelectLevel.jsx
+++ b/src/components/GameStages/SelectLevel.jsx
@@ -1,0 +1,11 @@
+import useStore from '../../store/useStore'
+
+
+const SelectLevel = () => {
+  const { setGameStage } = useStore((state) => state)
+
+  return null
+}
+
+
+export default SelectLevel;

--- a/src/components/GameStages/WinLevel.jsx
+++ b/src/components/GameStages/WinLevel.jsx
@@ -1,0 +1,28 @@
+import useStore from '../../store/useStore'
+import { GAME_STAGES } from '../../app.config'
+import { useEffect } from 'react'
+
+const WinLevel = () => {
+  const { gameStage } = useStore((state) => state)
+
+  useEffect(() => {
+
+    if (gameStage === GAME_STAGES.WinLevel) {
+      console.log('WinLevel Active')
+    }
+
+    // interval for exploding array of shapes
+
+    // when shapes array is empty, setGameStage(GAME_STAGES.IntroLevel)
+
+  }, [gameStage])
+
+  if (gameStage !== GAME_STAGES.WinLevel) {
+    return null
+  }
+
+  return null
+}
+
+
+export default WinLevel;

--- a/src/components/ShapeController/ShapeController.jsx
+++ b/src/components/ShapeController/ShapeController.jsx
@@ -1,9 +1,12 @@
 import useStore from '../../store/useStore'
 import CreateShape from '../CreateShape/CreateShape'
+import { Box3, Vector3 } from "three"
+import { useEffect, useRef } from 'react'
 
 
 const ShapeController = () => {
-  const { shapes, removeShape } = useStore((state) => state)
+  const { shapes, removeShape, setShapesBoxHeight, containerHeight } = useStore((state) => state)
+  const _groupRef = useRef(null)
 
   const handleRemoveShape = ({ name, position, color, chunkType }) => {
     removeShape({ 
@@ -14,8 +17,23 @@ const ShapeController = () => {
     }) 
   }
 
+  useEffect(() => {
+    const getShapesBoxHeight = () => {
+      if (!_groupRef.current) {
+        return
+      }
+      const _groupBox = new Box3().setFromObject(_groupRef.current);
+      const _groupBoxSize = new Vector3();
+      _groupBox.getSize(_groupBoxSize);
+      setShapesBoxHeight(_groupBoxSize.y)
+    }
+    const intervalId = setInterval(getShapesBoxHeight, 3000)
+    return () => clearInterval(intervalId)
+  }, [])
+
+
   return (
-    <group>
+    <group ref={_groupRef}>
       { shapes.map(({ type, props, key }) => CreateShape({
           type, 
           props: {...props, handleRemoveShape},

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 import Container from './Container/Container'
 import ExplosionController from './ExplosionController/ExplosionController'
+import GameStages from './GameStages/GameStages'
 import ScreenSettings from './ScreenSettings/ScreenSettings'
 import ShapeController from './ShapeController/ShapeController'
 import ChunkContainer from './ChunkContainer/ChunkContainer'
@@ -8,6 +9,7 @@ export {
   ChunkContainer,
   Container,
   ExplosionController,
+  GameStages,
   ScreenSettings,
   ShapeController
 }

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -1,9 +1,10 @@
 import { create } from 'zustand'
-import { CONTAINER } from '../app.config'
+import { CONTAINER, GAME_STAGES, LEVEL_ORDER } from '../app.config'
 import { getShapeProps } from './useStore.helpers'
 
 const useStore = create(
   (set) => ({
+    gameStage: GAME_STAGES.IntroLevel,
     // container
     containerDepth: CONTAINER.depth,
     containerHeight: undefined,
@@ -13,13 +14,15 @@ const useStore = create(
     explosions: {},
     // shapes
     shapes: [],
+    shapesBoxHeight: 0,
     shapeId: 2,
-    shapeLevel: 'boxes',
+    levelIndex: 0,
+    setShapesBoxHeight: (boxHeight) => set({ shapesBoxHeight: boxHeight }),
     spawnShape: ({x, y}) => {
       set((state) => {
         const _shapeId = state.shapeId + 1
         const _shapeProps = getShapeProps({ 
-          shapeLevel: state.shapeLevel, 
+          shapeLevel: LEVEL_ORDER[state.levelIndex], 
           shapeId: _shapeId,
           dropPosition: [x, y, 0] })
         return { shapes: [...state.shapes, _shapeProps], shapeId: _shapeId}
@@ -53,7 +56,17 @@ const useStore = create(
     setScreen: ({ width, height, orientation }) => set((state) => ({ 
       containerHeight: height / width * state.containerWidth,
       orientation,
-    }))
+    })),
+    setGameStage: (gameStage) => {
+      if (gameStage === GAME_STAGES.IntroLevel) {
+        set((state) => {
+          let _levelIndex = state.levelIndex + 1
+          _levelIndex = (_levelIndex + LEVEL_ORDER.length) % LEVEL_ORDER.length
+          return { levelIndex: _levelIndex }
+        })
+      }
+      set({ gameStage })
+    }
   })
 )
 


### PR DESCRIPTION
Ticket RGB-011
- Add game stages _IntroGame_, _SelectLevel_, _IntroLevel_, _PlayLevel_, and _WinLevel_
  - IntroGame: displays splash screen and start button
  - Selectlevel: menu of shapes for each level.
  - IntroLevel: three shapes of the level auto drop and then enable touches for subsequent drops.
  - PlayLevel: handles all gameplay until shapes stack to the top
  - WinLevel: touches disabled and win animation plays.

- After WinLevel completes animation, the game stage is set to IntroLevel with the next shape level. Current shape levels are:
  - spheres: ['sphere', 'sphere', 'sphere'],
  - boxes: ['box', 'box', 'box'],
  - sphereBoxSphere: ['sphere', 'box', 'sphere'],
  - boxSphereBox: ['box', 'sphere', 'box']